### PR TITLE
Refactor setClient/getClient to use owner as a context

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ Ember and Glimmer integration for Apollo Client.
 
 > **WIP: This project is currently in development.**
 >
-> Glimmer standalone integration is in a very early stage and not yet proven.
-> This should be possible to achieve though. See tracking issue
+> Glimmer standalone integration is in a very early stage.
+> See tracking issue
 > [#1](https://github.com/josemarluedke/glimmer-apollo/issues/1).
-> However, you can use with Ember today.
 
 ## API
 
@@ -93,20 +92,40 @@ export default class Todo extends Component {
 }
 ```
 
-### setClient(client[, clientId])
+### setClient(ctx, client[, clientId])
+
+Where `ctx` is an object with owner.
 
 ```js
 import { setClient } from 'glimmer-apollo';
 
-setClient(new ApolloClient({ ... });
+class App extends Component {
+  constructor() {
+    super(...arguments);
+
+    setClient(this, new ApolloClient({ ... });
+  }
+
+  // ...
+}
 ```
 
-### getClient()
+### getClient(ctx[,clientId])
+
+Where `ctx` is an object with owner.
 
 ```js
 import { getClient } from 'glimmer-apollo';
 
-const client = getClient([clientId]);
+class MyComponent extends Component {
+  constructor() {
+    super(...arguments);
+
+    getClient(this);
+  }
+
+  // ...
+}
 ```
 
 ## License

--- a/packages/glimmer-apollo/addon/-private/client.ts
+++ b/packages/glimmer-apollo/addon/-private/client.ts
@@ -1,20 +1,45 @@
+import { getOwner } from './environment';
 import type { ApolloClient } from '@apollo/client/core';
 
-const CLIENTS: Map<string, ApolloClient<unknown>> = new Map();
+const CLIENTS: WeakMap<
+  object,
+  Map<string, ApolloClient<unknown>>
+> = new WeakMap();
 const DEFAULT_CLIENT_ID = 'default';
 
 export function setClient<TCache = unknown>(
+  context: object,
   client: ApolloClient<TCache>,
   clientId: string = DEFAULT_CLIENT_ID
 ): void {
-  CLIENTS.set(clientId, client);
+  const owner = getOwner(context);
+
+  if (!owner) {
+    throw new Error(
+      'Unable to find owner from the given context in glimmer-apollo setClient'
+    );
+  }
+
+  if (!CLIENTS.has(owner)) {
+    CLIENTS.set(owner, new Map());
+  }
+
+  CLIENTS.get(owner)?.set(clientId, client);
 }
 
 export function getClient<TCache = unknown>(
+  context: object,
   clientId: string = DEFAULT_CLIENT_ID
 ): ApolloClient<TCache> {
-  const client = CLIENTS.get(clientId);
+  const owner = getOwner(context);
 
+  if (!owner) {
+    throw new Error(
+      'Unable to find owner from the given context in glimmer-apollo getClient'
+    );
+  }
+
+  const client = CLIENTS.get(owner)?.get(clientId);
   if (!client) {
     throw new Error(
       `Apollo client with id ${clientId} has not been set yet, use setClient(new ApolloClient({ ... }, '${clientId}')) to define it`
@@ -24,9 +49,18 @@ export function getClient<TCache = unknown>(
   return client as ApolloClient<TCache>;
 }
 
-export function clearClients(): void {
-  CLIENTS.forEach((client) => {
+export function clearClients(context: object): void {
+  const owner = getOwner(context);
+  if (!owner) {
+    throw new Error(
+      'Unable to find owner from the given context in glimmer-apollo getClient'
+    );
+  }
+
+  const bucket = CLIENTS.get(owner);
+  bucket?.forEach((client) => {
     client.clearStore();
   });
-  CLIENTS.clear();
+
+  bucket?.clear();
 }

--- a/packages/glimmer-apollo/addon/-private/mutation.ts
+++ b/packages/glimmer-apollo/addon/-private/mutation.ts
@@ -53,7 +53,7 @@ export class MutationResource<
     > = {}
   ): Promise<Maybe<TData>> {
     this.loading = true;
-    const client = getClient();
+    const client = getClient(this);
     const [mutation, originalOptions] = this.args.positional;
 
     if (!variables) {

--- a/packages/glimmer-apollo/addon/-private/query.ts
+++ b/packages/glimmer-apollo/addon/-private/query.ts
@@ -56,7 +56,7 @@ export class QueryResource<
 
   async setup(): Promise<void> {
     const [query, options] = this.args.positional;
-    const client = getClient();
+    const client = getClient(this);
 
     this.loading = true;
     const fastboot = this.getFastboot();

--- a/packages/glimmer-apollo/tests/dummy/app/instance-initializers/apollo.ts
+++ b/packages/glimmer-apollo/tests/dummy/app/instance-initializers/apollo.ts
@@ -5,10 +5,15 @@ import {
   InMemoryCache,
   createHttpLink
 } from '@apollo/client/core';
+import { setOwner } from '@ember/application';
 import type Application from '@ember/application';
 
 export function initialize(appInstance: Application): void {
+  const ctx = {};
+  setOwner(ctx, appInstance);
+
   setClient(
+    ctx,
     new ApolloClient({
       cache: new InMemoryCache(),
       link: createHttpLink({
@@ -18,7 +23,7 @@ export function initialize(appInstance: Application): void {
   );
 
   registerDestructor(appInstance, () => {
-    clearClients();
+    clearClients(ctx);
   });
 }
 

--- a/packages/glimmer-apollo/tests/unit/client-test.ts
+++ b/packages/glimmer-apollo/tests/unit/client-test.ts
@@ -1,34 +1,50 @@
 import { module, test } from 'qunit';
 import { setClient, getClient, clearClients } from 'glimmer-apollo';
 import { ApolloClient, InMemoryCache } from '@apollo/client/core';
+import { setOwner } from 'glimmer-apollo/-private/environment';
 
 module('setClient & getClient', function (hooks) {
+  const ctx = {};
+  const owner = {};
+  setOwner(ctx, owner);
+
   const cache = new InMemoryCache();
   const client = new ApolloClient({ cache });
 
   hooks.beforeEach(() => {
-    clearClients();
+    clearClients(ctx);
   });
 
   test('setting and getting a client without passing name', function (assert) {
-    setClient(client);
-    assert.equal(getClient(), client);
+    setClient(ctx, client);
+    assert.equal(getClient(ctx), client);
   });
 
   test('setting and getting client with custom name', function (assert) {
-    setClient(client, 'custom');
-    assert.equal(getClient('custom'), client);
+    setClient(ctx, client, 'custom');
+    assert.equal(getClient(ctx, 'custom'), client);
   });
 
   test('getting a client without setting before throws error', function (assert) {
     assert.throws(
-      () => getClient(),
+      () => getClient(ctx),
       /Apollo client with id default has not been set yet, use setClient/
     );
 
     assert.throws(
-      () => getClient('customClient'),
+      () => getClient(ctx, 'customClient'),
       /Apollo client with id customClient has not been set yet, use setClient/
+    );
+  });
+
+  test('geClient/setClient with context withou owner', function (assert) {
+    assert.throws(
+      () => setClient({}, client),
+      / Unable to find owner from the given context in glimmer-apollo setClient/
+    );
+    assert.throws(
+      () => getClient({}),
+      / Unable to find owner from the given context in glimmer-apollo getClient/
     );
   });
 });

--- a/packages/glimmer-apollo/tests/unit/mutation-test.ts
+++ b/packages/glimmer-apollo/tests/unit/mutation-test.ts
@@ -6,6 +6,7 @@ import {
   useMutation,
   getClient
 } from 'glimmer-apollo';
+import { setOwner } from 'glimmer-apollo/-private/environment';
 import { tracked } from '@glimmer/tracking';
 import {
   ApolloClient,
@@ -32,6 +33,8 @@ const LOGIN = gql`
 
 module('useMutation', function (hooks) {
   let ctx = {};
+  const owner = {};
+
   const client = new ApolloClient({
     cache: new InMemoryCache(),
     link: createHttpLink({
@@ -40,9 +43,11 @@ module('useMutation', function (hooks) {
   });
 
   hooks.beforeEach(() => {
-    clearClients();
-    setClient(client);
     ctx = {};
+    setOwner(ctx, owner);
+
+    clearClients(ctx);
+    setClient(ctx, client);
   });
 
   hooks.afterEach(() => {
@@ -108,7 +113,7 @@ module('useMutation', function (hooks) {
 
   test('it uses variables passed into mutate', async function (assert) {
     const sandbox = sinon.createSandbox();
-    const client = getClient();
+    const client = getClient(ctx);
 
     const mutate = sandbox.spy(client, 'mutate');
     const mutation = useMutation<LoginMutation, LoginMutationVariables>(
@@ -131,7 +136,7 @@ module('useMutation', function (hooks) {
 
   test('it merges variables passed into mutate', async function (assert) {
     const sandbox = sinon.createSandbox();
-    const client = getClient();
+    const client = getClient(ctx);
 
     const mutate = sandbox.spy(client, 'mutate');
     const mutation = useMutation<LoginMutation, LoginMutationVariables>(
@@ -157,7 +162,7 @@ module('useMutation', function (hooks) {
 
   test('it merges options passed into mutate', async function (assert) {
     const sandbox = sinon.createSandbox();
-    const client = getClient();
+    const client = getClient(ctx);
 
     const mutate = sandbox.spy(client, 'mutate');
     const mutation = useMutation<LoginMutation, LoginMutationVariables>(
@@ -284,7 +289,7 @@ module('useMutation', function (hooks) {
     }
     const vars = new Obj();
     const sandbox = sinon.createSandbox();
-    const client = getClient();
+    const client = getClient(ctx);
 
     const mutate = sandbox.spy(client, 'mutate');
     const mutation = useMutation<LoginMutation, LoginMutationVariables>(

--- a/packages/glimmer-apollo/tests/unit/query-test.ts
+++ b/packages/glimmer-apollo/tests/unit/query-test.ts
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { destroy } from '@ember/destroyable';
 import { tracked } from '@glimmer/tracking';
 import { setClient, clearClients, useQuery } from 'glimmer-apollo';
+import { setOwner } from 'glimmer-apollo/-private/environment';
 import {
   ApolloClient,
   ApolloError,
@@ -26,6 +27,8 @@ const USER_INFO = gql`
 
 module('useQuery', function (hooks) {
   let ctx = {};
+  const owner = {};
+
   const client = new ApolloClient({
     cache: new InMemoryCache(),
     link: createHttpLink({
@@ -34,9 +37,11 @@ module('useQuery', function (hooks) {
   });
 
   hooks.beforeEach(() => {
-    clearClients();
-    setClient(client);
     ctx = {};
+    setOwner(ctx, owner);
+
+    clearClients(ctx);
+    setClient(ctx, client);
   });
 
   hooks.afterEach(() => {

--- a/packages/test-glimmerx/src/App.ts
+++ b/packages/test-glimmerx/src/App.ts
@@ -7,7 +7,7 @@ import './App.css';
 export default class App extends Component<{}> {
   constructor(owner: object, args: {}) {
     super(owner, args);
-    createApollo();
+    createApollo(this);
   }
 
   static template = hbs`

--- a/packages/test-glimmerx/src/apollo.ts
+++ b/packages/test-glimmerx/src/apollo.ts
@@ -6,8 +6,9 @@ import {
   createHttpLink
 } from '@apollo/client/core';
 
-export default function createClient(): void {
+export default function createClient(ctx: object): void {
   setClient(
+    ctx,
     new ApolloClient({
       cache: new InMemoryCache(),
       link: createHttpLink({


### PR DESCRIPTION
This allows us to have multiple app instances without conflicting clients. This would be somewhat similar to context in other frameworks.