### PR TITLE
Revert "Refactor setClient/getClient to use owner as a context"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Ember and Glimmer integration for Apollo Client.
 
 > **WIP: This project is currently in development.**
 >
-> Glimmer standalone integration is in a very early stage.
-> See tracking issue
+> Glimmer standalone integration is in a very early stage and not yet proven.
+> This should be possible to achieve though. See tracking issue
 > [#1](https://github.com/josemarluedke/glimmer-apollo/issues/1).
+> However, you can use with Ember today.
 
 ## API
 
@@ -92,40 +93,20 @@ export default class Todo extends Component {
 }
 ```
 
-### setClient(ctx, client[, clientId])
-
-Where `ctx` is an object with owner.
+### setClient(client[, clientId])
 
 ```js
 import { setClient } from 'glimmer-apollo';
 
-class App extends Component {
-  constructor() {
-    super(...arguments);
-
-    setClient(this, new ApolloClient({ ... });
-  }
-
-  // ...
-}
+setClient(new ApolloClient({ ... });
 ```
 
-### getClient(ctx[,clientId])
-
-Where `ctx` is an object with owner.
+### getClient()
 
 ```js
 import { getClient } from 'glimmer-apollo';
 
-class MyComponent extends Component {
-  constructor() {
-    super(...arguments);
-
-    getClient(this);
-  }
-
-  // ...
-}
+const client = getClient([clientId]);
 ```
 
 ## License

--- a/packages/glimmer-apollo/addon/-private/mutation.ts
+++ b/packages/glimmer-apollo/addon/-private/mutation.ts
@@ -53,7 +53,7 @@ export class MutationResource<
     > = {}
   ): Promise<Maybe<TData>> {
     this.loading = true;
-    const client = getClient(this);
+    const client = getClient();
     const [mutation, originalOptions] = this.args.positional;
 
     if (!variables) {

--- a/packages/glimmer-apollo/addon/-private/query.ts
+++ b/packages/glimmer-apollo/addon/-private/query.ts
@@ -56,7 +56,7 @@ export class QueryResource<
 
   async setup(): Promise<void> {
     const [query, options] = this.args.positional;
-    const client = getClient(this);
+    const client = getClient();
 
     this.loading = true;
     const fastboot = this.getFastboot();

--- a/packages/glimmer-apollo/tests/dummy/app/instance-initializers/apollo.ts
+++ b/packages/glimmer-apollo/tests/dummy/app/instance-initializers/apollo.ts
@@ -5,15 +5,10 @@ import {
   InMemoryCache,
   createHttpLink
 } from '@apollo/client/core';
-import { setOwner } from '@ember/application';
 import type Application from '@ember/application';
 
 export function initialize(appInstance: Application): void {
-  const ctx = {};
-  setOwner(ctx, appInstance);
-
   setClient(
-    ctx,
     new ApolloClient({
       cache: new InMemoryCache(),
       link: createHttpLink({
@@ -23,7 +18,7 @@ export function initialize(appInstance: Application): void {
   );
 
   registerDestructor(appInstance, () => {
-    clearClients(ctx);
+    clearClients();
   });
 }
 

--- a/packages/glimmer-apollo/tests/unit/client-test.ts
+++ b/packages/glimmer-apollo/tests/unit/client-test.ts
@@ -1,50 +1,34 @@
 import { module, test } from 'qunit';
 import { setClient, getClient, clearClients } from 'glimmer-apollo';
 import { ApolloClient, InMemoryCache } from '@apollo/client/core';
-import { setOwner } from 'glimmer-apollo/-private/environment';
 
 module('setClient & getClient', function (hooks) {
-  const ctx = {};
-  const owner = {};
-  setOwner(ctx, owner);
-
   const cache = new InMemoryCache();
   const client = new ApolloClient({ cache });
 
   hooks.beforeEach(() => {
-    clearClients(ctx);
+    clearClients();
   });
 
   test('setting and getting a client without passing name', function (assert) {
-    setClient(ctx, client);
-    assert.equal(getClient(ctx), client);
+    setClient(client);
+    assert.equal(getClient(), client);
   });
 
   test('setting and getting client with custom name', function (assert) {
-    setClient(ctx, client, 'custom');
-    assert.equal(getClient(ctx, 'custom'), client);
+    setClient(client, 'custom');
+    assert.equal(getClient('custom'), client);
   });
 
   test('getting a client without setting before throws error', function (assert) {
     assert.throws(
-      () => getClient(ctx),
+      () => getClient(),
       /Apollo client with id default has not been set yet, use setClient/
     );
 
     assert.throws(
-      () => getClient(ctx, 'customClient'),
+      () => getClient('customClient'),
       /Apollo client with id customClient has not been set yet, use setClient/
-    );
-  });
-
-  test('geClient/setClient with context withou owner', function (assert) {
-    assert.throws(
-      () => setClient({}, client),
-      / Unable to find owner from the given context in glimmer-apollo setClient/
-    );
-    assert.throws(
-      () => getClient({}),
-      / Unable to find owner from the given context in glimmer-apollo getClient/
     );
   });
 });

--- a/packages/glimmer-apollo/tests/unit/mutation-test.ts
+++ b/packages/glimmer-apollo/tests/unit/mutation-test.ts
@@ -6,7 +6,6 @@ import {
   useMutation,
   getClient
 } from 'glimmer-apollo';
-import { setOwner } from 'glimmer-apollo/-private/environment';
 import { tracked } from '@glimmer/tracking';
 import {
   ApolloClient,
@@ -33,8 +32,6 @@ const LOGIN = gql`
 
 module('useMutation', function (hooks) {
   let ctx = {};
-  const owner = {};
-
   const client = new ApolloClient({
     cache: new InMemoryCache(),
     link: createHttpLink({
@@ -43,11 +40,9 @@ module('useMutation', function (hooks) {
   });
 
   hooks.beforeEach(() => {
+    clearClients();
+    setClient(client);
     ctx = {};
-    setOwner(ctx, owner);
-
-    clearClients(ctx);
-    setClient(ctx, client);
   });
 
   hooks.afterEach(() => {
@@ -113,7 +108,7 @@ module('useMutation', function (hooks) {
 
   test('it uses variables passed into mutate', async function (assert) {
     const sandbox = sinon.createSandbox();
-    const client = getClient(ctx);
+    const client = getClient();
 
     const mutate = sandbox.spy(client, 'mutate');
     const mutation = useMutation<LoginMutation, LoginMutationVariables>(
@@ -136,7 +131,7 @@ module('useMutation', function (hooks) {
 
   test('it merges variables passed into mutate', async function (assert) {
     const sandbox = sinon.createSandbox();
-    const client = getClient(ctx);
+    const client = getClient();
 
     const mutate = sandbox.spy(client, 'mutate');
     const mutation = useMutation<LoginMutation, LoginMutationVariables>(
@@ -162,7 +157,7 @@ module('useMutation', function (hooks) {
 
   test('it merges options passed into mutate', async function (assert) {
     const sandbox = sinon.createSandbox();
-    const client = getClient(ctx);
+    const client = getClient();
 
     const mutate = sandbox.spy(client, 'mutate');
     const mutation = useMutation<LoginMutation, LoginMutationVariables>(
@@ -289,7 +284,7 @@ module('useMutation', function (hooks) {
     }
     const vars = new Obj();
     const sandbox = sinon.createSandbox();
-    const client = getClient(ctx);
+    const client = getClient();
 
     const mutate = sandbox.spy(client, 'mutate');
     const mutation = useMutation<LoginMutation, LoginMutationVariables>(

--- a/packages/glimmer-apollo/tests/unit/query-test.ts
+++ b/packages/glimmer-apollo/tests/unit/query-test.ts
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { destroy } from '@ember/destroyable';
 import { tracked } from '@glimmer/tracking';
 import { setClient, clearClients, useQuery } from 'glimmer-apollo';
-import { setOwner } from 'glimmer-apollo/-private/environment';
 import {
   ApolloClient,
   ApolloError,
@@ -27,8 +26,6 @@ const USER_INFO = gql`
 
 module('useQuery', function (hooks) {
   let ctx = {};
-  const owner = {};
-
   const client = new ApolloClient({
     cache: new InMemoryCache(),
     link: createHttpLink({
@@ -37,11 +34,9 @@ module('useQuery', function (hooks) {
   });
 
   hooks.beforeEach(() => {
+    clearClients();
+    setClient(client);
     ctx = {};
-    setOwner(ctx, owner);
-
-    clearClients(ctx);
-    setClient(ctx, client);
   });
 
   hooks.afterEach(() => {

--- a/packages/test-glimmerx/src/App.ts
+++ b/packages/test-glimmerx/src/App.ts
@@ -7,7 +7,7 @@ import './App.css';
 export default class App extends Component<{}> {
   constructor(owner: object, args: {}) {
     super(owner, args);
-    createApollo(this);
+    createApollo();
   }
 
   static template = hbs`

--- a/packages/test-glimmerx/src/apollo.ts
+++ b/packages/test-glimmerx/src/apollo.ts
@@ -6,9 +6,8 @@ import {
   createHttpLink
 } from '@apollo/client/core';
 
-export default function createClient(ctx: object): void {
+export default function createClient(): void {
   setClient(
-    ctx,
     new ApolloClient({
       cache: new InMemoryCache(),
       link: createHttpLink({


### PR DESCRIPTION
Reverts josemarluedke/glimmer-apollo#5

Unfortunately, we can't do this because of testing env in glimmer standalone, it seems we can't have an owner there and it would make it difficult to set up apollo client in tests.