### PR TITLE
Error reproduction Ember Auto Import webpack externals

### DIFF
--- a/packages/test-app/ember-cli-build.js
+++ b/packages/test-app/ember-cli-build.js
@@ -4,7 +4,16 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
-    // Add options here
+    autoImport: {
+      webpack: {
+        externals: {
+          react: 'react'
+        }
+      }
+    },
+    babel: {
+      plugins: [require.resolve('ember-auto-import/babel-plugin')]
+    }
   });
 
   if (process.env.EMBROIDER) {


### PR DESCRIPTION
TO NOT BE MERGED

This shows a bug in ember-auto-import v2 while integrating with v2 addon. https://github.com/ef4/ember-auto-import/issues/412

This problem only appears when we add the following configuration for auto import:

```
        externals: {
          react: 'react'
        }
    
```


To reproduce:
- `git clone https://github.com/josemarluedke/glimmer-apollo.git`
- `git checkout bug/auto-import-externals`
- `yarn install`
- `cd packages/test-app`
- `ember s`


```
ERROR in ../../node_modules/@ember/test-waiters/addon/@ember/test-waiters/index.ts
Module build failed (from ../../node_modules/babel-loader/lib/index.js):
SyntaxError: /Users/josemarluedke/code/oss/glimmer-apollo/node_modules/@ember/test-waiters/addon/@ember/test-waiters/index.ts: Support for the experimental syntax 'flow' isn't currently enabled (1:8):

> 1 | export type {
    |        ^
  2 |   WaiterName,
  3 |   Token,
  4 |   Primitive,

Add @babel/preset-flow (https://git.io/JfeDn) to the 'presets' section of your Babel config to enable transformation.
If you want to leave it as-is, add @babel/plugin-syntax-flow (https://git.io/vb4yb) to the 'plugins' section to enable parsing.
    at Parser._raise (/Users/josemarluedke/code/oss/glimmer-apollo/node_modules/@babel/parser/lib/index.js:810:17)
    at Parser.raiseWithData (/Users/josemarluedke/code/oss/glimmer-apollo/node_modules/@babel/parser/lib/index.js:803:17)
    at Parser.expectOnePlugin (/Users/josemarluedke/code/oss/glimmer-apollo/node_modules/@babel/parser/lib/index.js:9982:18)
    at Parser.isExportDefaultSpecifier (/Users/josemarluedke/code/oss/glimmer-apollo/node_modules/@babel/parser/lib/index.js:13785:16)
    at Parser.maybeParseExportDefaultSpecifier (/Users/josemarluedke/code/oss/glimmer-apollo/node_modules/@babel/parser/lib/index.js:13686:14)
    at Parser.parseExport (/Users/josemarluedke/code/oss/glimmer-apollo/node_modules/@babel/parser/lib/index.js:13639:29)
    at Parser.parseStatementContent (/Users/josemarluedke/code/oss/glimmer-apollo/node_modules/@babel/parser/lib/index.js:12657:27)
    at Parser.parseStatement (/Users/josemarluedke/code/oss/glimmer-apollo/node_modules/@babel/parser/lib/index.js:12551:17)
    at Parser.parseBlockOrModuleBlockBody (/Users/josemarluedke/code/oss/glimmer-apollo/node_modules/@babel/parser/lib/index.js:13140:25)
    at Parser.parseBlockBody (/Users/josemarluedke/code/oss/glimmer-apollo/node_modules/@babel/parser/lib/index.js:13131:10)
 @ ../glimmer-apollo/dist/cjs/environment-ember.js 1:257-287
 @ ../../../../../../../private/var/folders/72/jd8jlwgs7mggxbv94t1b5k3c0000gn/T/broccoli-11145iViFBR5cSgFN/cache-149-webpack_bundler_ember_auto_import_webpack/app.js 24:66-109

ERROR in ../glimmer-apollo/dist/cjs/environment-ember.js 1:73-102
Module not found: Error: Can't resolve '@ember/application' in '/Users/josemarluedke/code/oss/glimmer-apollo/packages/glimmer-apollo/dist/cjs'
 @ ../../../../../../../private/var/folders/72/jd8jlwgs7mggxbv94t1b5k3c0000gn/T/broccoli-11145iViFBR5cSgFN/cache-149-webpack_bundler_ember_auto_import_webpack/app.js 24:66-109

ERROR in ../glimmer-apollo/dist/cjs/environment-ember.js 1:113-158
Module not found: Error: Can't resolve '@glimmer/tracking/primitives/cache' in '/Users/josemarluedke/code/oss/glimmer-apollo/packages/glimmer-apollo/dist/cjs'
 @ ../../../../../../../private/var/folders/72/jd8jlwgs7mggxbv94t1b5k3c0000gn/T/broccoli-11145iViFBR5cSgFN/cache-149-webpack_bundler_ember_auto_import_webpack/app.js 24:66-109

ERROR in ../glimmer-apollo/dist/cjs/environment-ember.js 1:170-194
Module not found: Error: Can't resolve '@ember/helper' in '/Users/josemarluedke/code/oss/glimmer-apollo/packages/glimmer-apollo/dist/cjs'
 @ ../../../../../../../private/var/folders/72/jd8jlwgs7mggxbv94t1b5k3c0000gn/T/broccoli-11145iViFBR5cSgFN/cache-149-webpack_bundler_ember_auto_import_webpack/app.js 24:66-109

ERROR in ../glimmer-apollo/dist/cjs/environment-ember.js 1:211-240
Module not found: Error: Can't resolve '@ember/destroyable' in '/Users/josemarluedke/code/oss/glimmer-apollo/packages/glimmer-apollo/dist/cjs'
 @ ../../../../../../../private/var/folders/72/jd8jlwgs7mggxbv94t1b5k3c0000gn/T/broccoli-11145iViFBR5cSgFN/cache-149-webpack_bundler_ember_auto_import_webpack/app.js 24:66-109
```
