### PR TITLE
GlimmerX refactor example setup to use provider

### DIFF
--- a/examples/glimmerx/src/apollo.ts
+++ b/examples/glimmerx/src/apollo.ts
@@ -1,18 +1,48 @@
-import 'glimmer-apollo/environment-glimmer';
-import { setClient } from 'glimmer-apollo';
+import { setClient, clearClients } from 'glimmer-apollo';
+import { registerDestructor } from '@glimmer/destroyable';
 import {
   ApolloClient,
   InMemoryCache,
   createHttpLink
 } from '@apollo/client/core';
+import Component, { hbs } from '@glimmerx/component';
 
-export default function createClient(): void {
-  setClient(
-    new ApolloClient({
-      cache: new InMemoryCache(),
-      link: createHttpLink({
-        uri: '/graphql'
-      })
-    })
-  );
+export class GlimmerApolloProvider extends Component<{}> {
+  constructor(owner: object, args: {}) {
+    super(owner, args);
+    setupApolloClient(this);
+  }
+
+  static template = hbs`
+    {{#if @Component}}
+      <@Component />
+    {{/if}}
+    {{yield}}
+  `;
+}
+
+export default function setupApolloClient(ctx: object): void {
+  // HTTP connection to the API
+  const httpLink = createHttpLink({
+    uri: '/graphql'
+  });
+
+  // Cache implementation
+  const cache = new InMemoryCache();
+
+  // Create the apollo client
+  const apolloClient = new ApolloClient({
+    link: httpLink,
+    cache
+  });
+
+  // Set default apollo client for Glimmer Apollo
+  setClient(apolloClient);
+
+  // Clear registered clients on tear down
+  if (ctx) {
+    registerDestructor(ctx, () => {
+      clearClients();
+    });
+  }
 }

--- a/examples/glimmerx/src/index.ts
+++ b/examples/glimmerx/src/index.ts
@@ -1,6 +1,8 @@
 import { renderComponent } from '@glimmerx/core';
+import { hbs } from '@glimmerx/component';
+import 'glimmer-apollo/environment-glimmer';
+import { GlimmerApolloProvider } from './apollo';
 import { startServer } from './mock/server';
-import createApollo from './apollo';
 import App from './App';
 
 document.addEventListener(
@@ -8,12 +10,17 @@ document.addEventListener(
   () => {
     const server = startServer('development');
     server.createList('note', 3);
-    createApollo();
 
     const element = document.getElementById('app');
-    renderComponent(App, {
-      element: element! // eslint-disable-line
-    });
+    renderComponent(
+      hbs`<GlimmerApolloProvider>
+            <App />
+          </GlimmerApolloProvider>
+        `,
+      {
+        element: element! // eslint-disable-line
+      }
+    );
   },
   { once: true }
 );

--- a/examples/glimmerx/tests/rendering/App.test.js
+++ b/examples/glimmerx/tests/rendering/App.test.js
@@ -1,20 +1,14 @@
-import {
-  module,
-  test,
-  renderComponent,
-  setupApollo,
-  setupMirage
-} from '../util';
+import { module, test, renderComponent, setupMirage } from '../util';
+import { hbs } from '@glimmerx/component';
 
 import App from '../../src/App';
 
 module('App test', (hooks) => {
   const mirage = setupMirage(hooks);
-  setupApollo(hooks);
 
   test('it works', async (assert) => {
     mirage.server.createList('note', 3);
-    await renderComponent(App);
+    await renderComponent(hbs`<App />`);
 
     assert.dom('h1').containsText('Notes');
   });

--- a/examples/glimmerx/tests/util.ts
+++ b/examples/glimmerx/tests/util.ts
@@ -1,11 +1,11 @@
+import 'glimmer-apollo/environment-glimmer';
 import {
   renderComponent as glimmerRenderComponent,
   ComponentDefinition,
   RenderComponentOptions,
   didRender
 } from '@glimmerx/core';
-import createApollo from '../src/apollo';
-import { clearClients } from 'glimmer-apollo';
+import { GlimmerApolloProvider } from '../src/apollo';
 
 // Bootstrap QUnit
 import 'qunit';
@@ -42,16 +42,9 @@ export async function renderComponent(
     options = { ...elementOrOptions, element };
   }
 
-  await glimmerRenderComponent(component, options);
-}
+  options.args = { Component: component };
 
-export function setupApollo(hooks: NestedHooks): void {
-  hooks.beforeEach(() => {
-    createApollo();
-  });
-  hooks.afterEach(() => {
-    clearClients();
-  });
+  await glimmerRenderComponent(GlimmerApolloProvider, options);
 }
 
 export function setupMirage(hooks: NestedHooks): {


### PR DESCRIPTION
With this refactor, we will be able to re-add the concept of adding clients to the context, which was reverted in #6.