### PR TITLE
Refactor setClient/getClient and others to use owner as a context

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,20 +109,40 @@ export default class Todo extends Component {
 }
 ```
 
-### setClient(client[, clientId])
+### setClient(ctx, client[, clientId])
+
+Where `ctx` is an object with owner.
 
 ```js
 import { setClient } from 'glimmer-apollo';
 
-setClient(new ApolloClient({ ... });
+class App extends Component {
+  constructor() {
+    super(...arguments);
+
+    setClient(this, new ApolloClient({ ... });
+  }
+
+  // ...
+}
 ```
 
-### getClient([clientId])
+### getClient(ctx[,clientId])
+
+Where `ctx` is an object with owner.
 
 ```js
 import { getClient } from 'glimmer-apollo';
 
-const client = getClient();
+class MyComponent extends Component {
+  constructor() {
+    super(...arguments);
+
+    const client = getClient(this);
+  }
+
+  // ...
+}
 ```
 
 ## Ember Setup
@@ -136,8 +156,7 @@ Here is an example:
 ```js
 // app/instance-initializers/apollo.js
 
-import { registerDestructor } from '@ember/destroyable';
-import { setClient, clearClients } from 'glimmer-apollo';
+import { setClient } from 'glimmer-apollo';
 import {
   ApolloClient,
   InMemoryCache,
@@ -146,6 +165,7 @@ import {
 
 export function initialize(appInstance) {
   setClient(
+    appInstance,
     new ApolloClient({
       cache: new InMemoryCache(),
       link: createHttpLink({
@@ -153,10 +173,6 @@ export function initialize(appInstance) {
       })
     })
   );
-
-  registerDestructor(appInstance, () => {
-    clearClients();
-  });
 }
 
 export default {
@@ -164,8 +180,8 @@ export default {
 };
 ```
 
-> Note that you should clear the Apollo client when the application is
-> torn down so that any cache that Apollo holds is cleared from memory.
+> Note that when the context (application instance) is torn down, the
+> Apollo Client will be cleared and unregistered from Glimmer Apollo.
 
 ## License
 

--- a/examples/glimmerx/src/apollo.ts
+++ b/examples/glimmerx/src/apollo.ts
@@ -1,11 +1,11 @@
-import { setClient, clearClients } from 'glimmer-apollo';
-import { registerDestructor } from '@glimmer/destroyable';
+import Component, { hbs } from '@glimmerx/component';
+
+import { setClient } from 'glimmer-apollo';
 import {
   ApolloClient,
   InMemoryCache,
   createHttpLink
 } from '@apollo/client/core';
-import Component, { hbs } from '@glimmerx/component';
 
 export class GlimmerApolloProvider extends Component<{}> {
   constructor(owner: object, args: {}) {
@@ -37,12 +37,5 @@ export default function setupApolloClient(ctx: object): void {
   });
 
   // Set default apollo client for Glimmer Apollo
-  setClient(apolloClient);
-
-  // Clear registered clients on tear down
-  if (ctx) {
-    registerDestructor(ctx, () => {
-      clearClients();
-    });
-  }
+  setClient(ctx, apolloClient);
 }

--- a/packages/glimmer-apollo/src/-private/client.ts
+++ b/packages/glimmer-apollo/src/-private/client.ts
@@ -1,20 +1,47 @@
+import { getOwner, registerDestructor } from '../environment';
 import type { ApolloClient } from '@apollo/client/core';
 
-const CLIENTS: Map<string, ApolloClient<unknown>> = new Map();
+const CLIENTS: WeakMap<object, Map<string, ApolloClient<unknown>>> =
+  new WeakMap();
 const DEFAULT_CLIENT_ID = 'default';
 
 export function setClient<TCache = unknown>(
+  context: object,
   client: ApolloClient<TCache>,
   clientId: string = DEFAULT_CLIENT_ID
 ): void {
-  CLIENTS.set(clientId, client);
+  const owner = getOwner(context);
+
+  if (!owner) {
+    throw new Error(
+      'Unable to find owner from the given context in glimmer-apollo setClient'
+    );
+  }
+
+  if (!CLIENTS.has(owner)) {
+    CLIENTS.set(owner, new Map());
+  }
+
+  CLIENTS.get(owner)?.set(clientId, client);
+
+  registerDestructor(context, () => {
+    clearClient(context, clientId);
+  });
 }
 
 export function getClient<TCache = unknown>(
+  context: object,
   clientId: string = DEFAULT_CLIENT_ID
 ): ApolloClient<TCache> {
-  const client = CLIENTS.get(clientId);
+  const owner = getOwner(context);
 
+  if (!owner) {
+    throw new Error(
+      'Unable to find owner from the given context in glimmer-apollo getClient'
+    );
+  }
+
+  const client = CLIENTS.get(owner)?.get(clientId);
   if (!client) {
     throw new Error(
       `Apollo client with id ${clientId} has not been set yet, use setClient(new ApolloClient({ ... }, '${clientId}')) to define it`
@@ -24,9 +51,38 @@ export function getClient<TCache = unknown>(
   return client as ApolloClient<TCache>;
 }
 
-export function clearClients(): void {
-  CLIENTS.forEach((client) => {
+export function clearClients(context: object): void {
+  const owner = getOwner(context);
+  if (!owner) {
+    throw new Error(
+      'Unable to find owner from the given context in glimmer-apollo clearClients'
+    );
+  }
+
+  const bucket = CLIENTS.get(owner);
+  bucket?.forEach((client) => {
     client.clearStore();
   });
-  CLIENTS.clear();
+
+  bucket?.clear();
+}
+
+export function clearClient(
+  context: object,
+  clientId: string = DEFAULT_CLIENT_ID
+): void {
+  const owner = getOwner(context);
+  if (!owner) {
+    throw new Error(
+      'Unable to find owner from the given context in glimmer-apollo clearClient'
+    );
+  }
+
+  const bucket = CLIENTS.get(owner);
+
+  const client = bucket?.get(clientId);
+  if (client) {
+    client.clearStore();
+  }
+  bucket?.delete(clientId);
 }

--- a/packages/glimmer-apollo/src/-private/mutation.ts
+++ b/packages/glimmer-apollo/src/-private/mutation.ts
@@ -53,7 +53,7 @@ export class MutationResource<
     > = {}
   ): Promise<Maybe<TData>> {
     this.loading = true;
-    const client = getClient();
+    const client = getClient(this);
     const [mutation, originalOptions] = this.args.positional;
 
     if (!variables) {

--- a/packages/glimmer-apollo/src/-private/query.ts
+++ b/packages/glimmer-apollo/src/-private/query.ts
@@ -56,7 +56,7 @@ export class QueryResource<
   async setup(): Promise<void> {
     this.previousPositionalArgs = this.args.positional;
     const [query, options] = this.args.positional;
-    const client = getClient();
+    const client = getClient(this);
 
     this.loading = true;
     const fastboot = this.getFastboot();

--- a/packages/glimmer-apollo/src/environment-ember.ts
+++ b/packages/glimmer-apollo/src/environment-ember.ts
@@ -1,5 +1,6 @@
 import { setEnviromentContext } from './environment';
 import { getOwner, setOwner } from '@ember/application';
+import ApplicationInstance from '@ember/application/instance';
 import { getValue, createCache } from '@glimmer/tracking/primitives/cache';
 import { invokeHelper } from '@ember/helper';
 import {
@@ -17,6 +18,7 @@ import {
 } from '@ember/helper';
 
 setEnviromentContext({
+  owner: ApplicationInstance,
   getOwner,
   setOwner,
   createCache: createCache as never,

--- a/packages/glimmer-apollo/src/environment.ts
+++ b/packages/glimmer-apollo/src/environment.ts
@@ -28,6 +28,7 @@ import type {
 } from '@glimmer/validator';
 
 interface EnviromentContext {
+  owner?: object;
   setOwner: typeof ISetOwner;
   getOwner: typeof IGetOwner;
   getValue: typeof IGetValue;
@@ -43,7 +44,8 @@ interface EnviromentContext {
   helperCapabilities: typeof IHelperCapabilities;
 }
 
-export let getOwner: EnviromentContext['getOwner'];
+export let owner: EnviromentContext['owner'];
+let _getOwner: EnviromentContext['getOwner'];
 export let setOwner: EnviromentContext['setOwner'];
 export let createCache: EnviromentContext['createCache'];
 export let getValue: EnviromentContext['getValue'];
@@ -59,6 +61,15 @@ export let helperCapabilities: EnviromentContext['helperCapabilities'];
 
 let environmentContextWasSet = false;
 
+export function getOwner<O extends object>(obj: object): O | undefined {
+  // eslint-disable-next-line
+  if (typeof owner !== 'undefined' && obj instanceof (owner as any)) {
+    return obj as O;
+  }
+
+  return _getOwner(obj);
+}
+
 export function setEnviromentContext(env: EnviromentContext): void {
   if (DEBUG) {
     if (environmentContextWasSet) {
@@ -70,8 +81,9 @@ export function setEnviromentContext(env: EnviromentContext): void {
     environmentContextWasSet = true;
   }
 
+  owner = env.owner;
   setOwner = env.setOwner;
-  getOwner = env.getOwner;
+  _getOwner = env.getOwner;
   createCache = env.createCache;
   getValue = env.getValue;
   invokeHelper = env.invokeHelper;

--- a/packages/glimmer-apollo/src/index.ts
+++ b/packages/glimmer-apollo/src/index.ts
@@ -1,2 +1,7 @@
-export { getClient, setClient, clearClients } from './-private/client';
+export {
+  getClient,
+  setClient,
+  clearClient,
+  clearClients
+} from './-private/client';
 export { useQuery, useMutation } from './-private/usables';

--- a/packages/test-app/app/instance-initializers/apollo.ts
+++ b/packages/test-app/app/instance-initializers/apollo.ts
@@ -1,14 +1,14 @@
-import { registerDestructor } from '@ember/destroyable';
-import { setClient, clearClients } from 'glimmer-apollo';
+import { setClient } from 'glimmer-apollo';
 import {
   ApolloClient,
   InMemoryCache,
   createHttpLink
 } from '@apollo/client/core';
-import type Application from '@ember/application';
+import ApplicationInstance from '@ember/application/instance';
 
-export function initialize(appInstance: Application): void {
+export function initialize(appInstance: ApplicationInstance): void {
   setClient(
+    appInstance,
     new ApolloClient({
       cache: new InMemoryCache(),
       link: createHttpLink({
@@ -16,10 +16,6 @@ export function initialize(appInstance: Application): void {
       })
     })
   );
-
-  registerDestructor(appInstance, () => {
-    clearClients();
-  });
 }
 
 export default {

--- a/packages/test-app/tests/unit/client-test.ts
+++ b/packages/test-app/tests/unit/client-test.ts
@@ -1,33 +1,97 @@
 import { module, test } from 'qunit';
-import { setClient, getClient, clearClients } from 'glimmer-apollo';
+import {
+  setClient,
+  getClient,
+  clearClient,
+  clearClients
+} from 'glimmer-apollo';
 import { ApolloClient, InMemoryCache } from '@apollo/client/core';
+import { setOwner } from '@ember/application';
+import { destroy } from '@ember/destroyable';
 
 module('setClient & getClient', function (hooks) {
+  let ctx = {};
+  const owner = {};
+
   const cache = new InMemoryCache();
   const client = new ApolloClient({ cache });
 
   hooks.beforeEach(() => {
-    clearClients();
+    ctx = {};
+    setOwner(ctx, owner);
+  });
+
+  hooks.afterEach(() => {
+    destroy(ctx);
   });
 
   test('setting and getting a client without passing name', function (assert) {
-    setClient(client);
-    assert.equal(getClient(), client);
+    setClient(ctx, client);
+    assert.equal(getClient(ctx), client);
   });
 
   test('setting and getting client with custom name', function (assert) {
-    setClient(client, 'custom');
-    assert.equal(getClient('custom'), client);
+    setClient(ctx, client, 'custom');
+    assert.equal(getClient(ctx, 'custom'), client);
   });
 
   test('getting a client without setting before throws error', function (assert) {
     assert.throws(
-      () => getClient(),
+      () => getClient(ctx),
       /Apollo client with id default has not been set yet, use setClient/
     );
 
     assert.throws(
-      () => getClient('customClient'),
+      () => getClient(ctx, 'customClient'),
+      /Apollo client with id customClient has not been set yet, use setClient/
+    );
+  });
+
+  test('geClient/setClient with context withou owner', function (assert) {
+    assert.throws(
+      () => setClient({}, client),
+      / Unable to find owner from the given context in glimmer-apollo setClient/
+    );
+    assert.throws(
+      () => getClient({}),
+      / Unable to find owner from the given context in glimmer-apollo getClient/
+    );
+  });
+
+  test('clearClient removes the client from context', function (assert) {
+    setClient(ctx, client);
+    setClient(ctx, client, 'customClient');
+    assert.equal(getClient(ctx), client);
+    assert.equal(getClient(ctx, 'customClient'), client);
+
+    clearClient(ctx);
+
+    assert.equal(
+      getClient(ctx, 'customClient'),
+      client,
+      'should not have removed customClient'
+    );
+
+    assert.throws(
+      () => getClient(ctx),
+      /Apollo client with id default has not been set yet, use setClient/
+    );
+  });
+
+  test('clearClients removes all clients from context', function (assert) {
+    setClient(ctx, client);
+    setClient(ctx, client, 'customClient');
+    assert.equal(getClient(ctx), client);
+    assert.equal(getClient(ctx, 'customClient'), client);
+    clearClients(ctx);
+
+    assert.throws(
+      () => getClient(ctx),
+      /Apollo client with id default has not been set yet, use setClient/
+    );
+
+    assert.throws(
+      () => getClient(ctx, 'customClient'),
       /Apollo client with id customClient has not been set yet, use setClient/
     );
   });

--- a/packages/test-app/tests/unit/mutation-test.ts
+++ b/packages/test-app/tests/unit/mutation-test.ts
@@ -6,6 +6,7 @@ import {
   useMutation,
   getClient
 } from 'glimmer-apollo';
+import { setOwner } from '@ember/application';
 import { tracked } from '@glimmer/tracking';
 import {
   ApolloClient,
@@ -32,6 +33,8 @@ const LOGIN = gql`
 
 module('useMutation', function (hooks) {
   let ctx = {};
+  const owner = {};
+
   const client = new ApolloClient({
     cache: new InMemoryCache(),
     link: createHttpLink({
@@ -40,9 +43,11 @@ module('useMutation', function (hooks) {
   });
 
   hooks.beforeEach(() => {
-    clearClients();
-    setClient(client);
     ctx = {};
+    setOwner(ctx, owner);
+
+    clearClients(ctx);
+    setClient(ctx, client);
   });
 
   hooks.afterEach(() => {
@@ -108,7 +113,7 @@ module('useMutation', function (hooks) {
 
   test('it uses variables passed into mutate', async function (assert) {
     const sandbox = sinon.createSandbox();
-    const client = getClient();
+    const client = getClient(ctx);
 
     const mutate = sandbox.spy(client, 'mutate');
     const mutation = useMutation<LoginMutation, LoginMutationVariables>(
@@ -131,7 +136,7 @@ module('useMutation', function (hooks) {
 
   test('it merges variables passed into mutate', async function (assert) {
     const sandbox = sinon.createSandbox();
-    const client = getClient();
+    const client = getClient(ctx);
 
     const mutate = sandbox.spy(client, 'mutate');
     const mutation = useMutation<LoginMutation, LoginMutationVariables>(
@@ -157,7 +162,7 @@ module('useMutation', function (hooks) {
 
   test('it merges options passed into mutate', async function (assert) {
     const sandbox = sinon.createSandbox();
-    const client = getClient();
+    const client = getClient(ctx);
 
     const mutate = sandbox.spy(client, 'mutate');
     const mutation = useMutation<LoginMutation, LoginMutationVariables>(
@@ -284,7 +289,7 @@ module('useMutation', function (hooks) {
     }
     const vars = new Obj();
     const sandbox = sinon.createSandbox();
-    const client = getClient();
+    const client = getClient(ctx);
 
     const mutate = sandbox.spy(client, 'mutate');
     const mutation = useMutation<LoginMutation, LoginMutationVariables>(

--- a/packages/test-app/tests/unit/query-test.ts
+++ b/packages/test-app/tests/unit/query-test.ts
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { destroy } from '@ember/destroyable';
 import { tracked } from '@glimmer/tracking';
-import { setClient, getClient, clearClients, useQuery } from 'glimmer-apollo';
+import { setClient, getClient, useQuery } from 'glimmer-apollo';
+import { setOwner } from '@ember/application';
 import {
   ApolloClient,
   ApolloError,
@@ -27,6 +28,8 @@ const USER_INFO = gql`
 
 module('useQuery', function (hooks) {
   let ctx = {};
+  const owner = {};
+
   const client = new ApolloClient({
     cache: new InMemoryCache(),
     link: createHttpLink({
@@ -35,9 +38,9 @@ module('useQuery', function (hooks) {
   });
 
   hooks.beforeEach(() => {
-    clearClients();
-    setClient(client);
     ctx = {};
+    setOwner(ctx, owner);
+    setClient(ctx, client);
   });
 
   hooks.afterEach(() => {
@@ -206,7 +209,7 @@ module('useQuery', function (hooks) {
     }
     const vars = new Obj();
     const sandbox = sinon.createSandbox();
-    const client = getClient();
+    const client = getClient(ctx);
 
     const watchQuery = sandbox.spy(client, 'watchQuery');
     const query = useQuery<UserInfoQuery, UserInfoQueryVariables>(ctx, () => [


### PR DESCRIPTION
This concept was originally introduced in #5 and later reverted in #6. Recently I have figured a way around to the original issue that made required to revert these changes (#20). 

We now scope all the clients around the owner, allowing us to have multiple app instances without conflicting apollo clients.


Note that we automatically clear out the client when the context (object with owner) gets destroyed. Which removes the need to manually clear up a client.