### PR TITLE
Add UseQuery & UseMutation types

### DIFF
--- a/packages/glimmer-apollo/src/-private/usables.ts
+++ b/packages/glimmer-apollo/src/-private/usables.ts
@@ -22,3 +22,17 @@ export function useMutation<TData = unknown, TVariables = OperationVariables>(
     MutationResource<TData, TVariables>
   >(parentDestroyable, MutationResource, args);
 }
+
+export type UseQuery<TData = unknown, TVariables = OperationVariables> = {
+  args: () => QueryPositionalArgs<TData, TVariables>[1];
+  return: QueryResource<TData, TVariables>;
+  data: TData;
+  variables: TVariables;
+};
+
+export type UseMutation<TData = unknown, TVariables = OperationVariables> = {
+  args: () => MutationPositionalArgs<TData, TVariables>[1];
+  return: MutationResource<TData, TVariables>;
+  data: TData;
+  variables: TVariables;
+};

--- a/packages/glimmer-apollo/src/index.ts
+++ b/packages/glimmer-apollo/src/index.ts
@@ -4,5 +4,6 @@ export {
   clearClient,
   clearClients
 } from './-private/client';
-export { useQuery, useMutation } from './-private/usables';
 export { gql } from '@apollo/client/core';
+export { useQuery, useMutation } from './-private/usables';
+export type { UseQuery, UseMutation } from './-private/usables';


### PR DESCRIPTION
This will allow us to create `useXYZQuery` functions with pre-defining the types and the query:

```ts
export function useMyQuery<
  T extends UseQuery<{ cool: boolean }, { isCool: boolean }>
>(ctx: Object, args?: T['args']): T['return'] {
  return useQuery(ctx, () => [
    gql`
      query {
        myQuery {
          id
        }
      }
    `,
    args ? args() : {}
  ]);
}

class MyComponent extends Component {
  myQuery = useMyQuery(this, () => {
    return { variables: { isCool: true } };
  })
}
```