### PR TITLE
Fix babel config to allow interop with legacy decorators and class props

### DIFF
--- a/packages/glimmer-apollo/babel.config.js
+++ b/packages/glimmer-apollo/babel.config.js
@@ -13,5 +13,9 @@ module.exports = {
         }
       }
     ]
-  ]
+  ],
+  assumptions: {
+    // For legacy decorator support with class fields to work
+    setPublicClassFields: true
+  }
 };


### PR DESCRIPTION
This bug was introduced in the last PR #35

This prevented tracked decorator to work correctly.