### PR TITLE
Prevent accessing self when undefined

### DIFF
--- a/packages/glimmer-apollo/src/-private/utils.ts
+++ b/packages/glimmer-apollo/src/-private/utils.ts
@@ -13,7 +13,11 @@ function ownerHasLookup(
 }
 
 export function getFastboot(ctx: Object): Fastboot | undefined {
-  if (hasFastBoot(self) && typeof self.FastBoot !== 'undefined') {
+  if (
+    typeof self != 'undefined' &&
+    hasFastBoot(self) &&
+    typeof self.FastBoot !== 'undefined'
+  ) {
     const owner = getOwner(ctx);
 
     if (ownerHasLookup(owner) && typeof owner.lookup === 'function') {


### PR DESCRIPTION
Prevent accessing self when undefined. I saw this problem when running in SSR mode using Vite.