### PR TITLE
[docs] Update onComplete docs to highlight that its called only when the query/mutation has succeeded

### DIFF
--- a/docs/fetching/mutations.md
+++ b/docs/fetching/mutations.md
@@ -328,7 +328,7 @@ allowing you to execute code when a specific event occurs.
 
 ### `onComplete`
 
-This callback gets called when the mutation completes execution.
+This callback gets called when the mutation successfully completes execution.
 
 ```ts
 createNote = useMutation(this, () => [

--- a/docs/fetching/queries.md
+++ b/docs/fetching/queries.md
@@ -317,7 +317,7 @@ allowing you to execute code when a specific event occurs.
 
 ### `onComplete`
 
-This callback gets called when the query completes execution and when the
+This callback gets called when the query successfully completes execution and when the
 cache associated with this query is updated.
 
 ```js


### PR DESCRIPTION
Updated onComplete docs to highlight that its called only when the query/mutation has succeeded