### PR TITLE
Allow `ember-source` v4 as peer dependency

### DIFF
--- a/packages/glimmer-apollo/package.json
+++ b/packages/glimmer-apollo/package.json
@@ -60,7 +60,7 @@
     "@glimmer/runtime": "^0.77.6",
     "@glimmer/tracking": "^2.0.0-beta.15",
     "@glimmer/validator": "^0.77.6",
-    "ember-source": "^3.27.0",
+    "ember-source": "^3.27.0 || ^4.0.0",
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Closes #72.