### PR TITLE
Make `@glimmer/runtime` an optional peer dependency

### DIFF
--- a/packages/glimmer-apollo/package.json
+++ b/packages/glimmer-apollo/package.json
@@ -76,6 +76,9 @@
     "@glimmer/owner": {
       "optional": true
     },
+    "@glimmer/runtime": {
+      "optional": true
+    },
     "@glimmer/validator": {
       "optional": true
     }


### PR DESCRIPTION
AFAICT, for Ember apps, this is provided via `ember-source`?

Closes #70.