### PR TITLE
Resolve: #78 TVariables type now must extend from OperationVariable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
       - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn lint:js
       - run: yarn build
-      - run: yarn test:types
 
   package-tests:
     name: Glimmer Apollo Tests
@@ -69,6 +68,34 @@ jobs:
         env:
           EMBER_TRY_SCENARIO: ${{ matrix.ember-try-scenario }}
         run: yarn workspace test-app run ember try:one $EMBER_TRY_SCENARIO
+
+  typescript:
+    name: ${{ matrix.typecsript }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        typescript:
+          - typescript@~4.5.0
+          - typescript@~4.6.0
+          - typescript@~4.7.0
+          - typescript@~4.8.0
+          - typescript@~4.9.0
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: volta-cli/action@v1
+        with:
+          node-version: 14.x
+          yarn-version: 1.x
+      - run: yarn install --frozen-lockfile --non-interactive
+      - run: yarn add --dev ${{ matrix.typescript }}
+        working-directory: examples/glimmerx
+      - run: yarn add --dev ${{ matrix.typescript }}
+        working-directory: packages/glimmer-apollo
+      - run: yarn test:types
+
 
   examples-glimmerx:
     name: GlimmerX Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
           node-version: 14.x
           yarn-version: 1.x
       - run: yarn install --frozen-lockfile --non-interactive
+      - run: yarn build
       - run: yarn add --dev ${{ matrix.typescript }}
         working-directory: examples/glimmerx
       - run: yarn add --dev ${{ matrix.typescript }}

--- a/packages/glimmer-apollo/src/-private/observable.ts
+++ b/packages/glimmer-apollo/src/-private/observable.ts
@@ -4,6 +4,7 @@ import type {
   FetchMoreOptions,
   FetchMoreQueryOptions,
   ObservableQuery,
+  OperationVariables,
   SubscribeToMoreOptions,
   UpdateQueryOptions
 } from '@apollo/client/core';
@@ -11,7 +12,7 @@ import type { TemplateArgs } from './types';
 
 export default class ObservableResource<
   TData,
-  TVariables,
+  TVariables extends OperationVariables,
   Args extends TemplateArgs
 > extends Resource<Args> {
   private observable?: ObservableQuery<TData>;

--- a/packages/glimmer-apollo/src/-private/query.ts
+++ b/packages/glimmer-apollo/src/-private/query.ts
@@ -35,7 +35,7 @@ export type QueryPositionalArgs<TData, TVariables = OperationVariables> = [
 
 export class QueryResource<
   TData,
-  TVariables = OperationVariables
+  TVariables extends OperationVariables = OperationVariables
 > extends ObservableResource<
   TData,
   TVariables,

--- a/packages/glimmer-apollo/src/-private/usables.ts
+++ b/packages/glimmer-apollo/src/-private/usables.ts
@@ -7,7 +7,10 @@ import {
 } from './subscription';
 import type { OperationVariables } from '@apollo/client/core';
 
-export function useQuery<TData = unknown, TVariables = OperationVariables>(
+export function useQuery<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables
+>(
   parentDestroyable: object,
   args: () => QueryPositionalArgs<TData, TVariables>
 ): QueryResource<TData, TVariables> {
@@ -17,7 +20,10 @@ export function useQuery<TData = unknown, TVariables = OperationVariables>(
   >(parentDestroyable, QueryResource, args);
 }
 
-export function useMutation<TData = unknown, TVariables = OperationVariables>(
+export function useMutation<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables
+>(
   parentDestroyable: object,
   args: () => MutationPositionalArgs<TData, TVariables>
 ): MutationResource<TData, TVariables> {
@@ -40,14 +46,20 @@ export function useSubscription<
   >(parentDestroyable, SubscriptionResource, args);
 }
 
-export type UseQuery<TData = unknown, TVariables = OperationVariables> = {
+export type UseQuery<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables
+> = {
   args: () => QueryPositionalArgs<TData, TVariables>[1];
   return: QueryResource<TData, TVariables>;
   data: TData;
   variables: TVariables;
 };
 
-export type UseMutation<TData = unknown, TVariables = OperationVariables> = {
+export type UseMutation<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables
+> = {
   args: () => MutationPositionalArgs<TData, TVariables>[1];
   return: MutationResource<TData, TVariables>;
   data: TData;


### PR DESCRIPTION
Also resolves #76. 

This is a breaking change because the TVariables type now must extend from OperationVariables, whereas before there was no constraint.

Because this library is pre 1.0, I think this is ok.