### PR TITLE
Fix missing constraints on variable types, especially for TS 4.9

### DIFF
--- a/packages/glimmer-apollo/src/-private/mutation.ts
+++ b/packages/glimmer-apollo/src/-private/mutation.ts
@@ -27,14 +27,14 @@ export interface MutationOptions<TData, TVariables>
   onError?: (error: ApolloError) => void;
 }
 
-export type MutationPositionalArgs<TData, TVariables = OperationVariables> = [
-  DocumentNode,
-  MutationOptions<TData, TVariables>?
-];
+export type MutationPositionalArgs<
+  TData,
+  TVariables extends OperationVariables = OperationVariables
+> = [DocumentNode, MutationOptions<TData, TVariables>?];
 
 export class MutationResource<
   TData,
-  TVariables = OperationVariables
+  TVariables extends OperationVariables = OperationVariables
 > extends Resource<TemplateArgs<MutationPositionalArgs<TData, TVariables>>> {
   @tracked loading = false;
   @tracked called = false;

--- a/packages/glimmer-apollo/src/-private/query.ts
+++ b/packages/glimmer-apollo/src/-private/query.ts
@@ -20,7 +20,7 @@ import type {
 } from '@apollo/client/core';
 import type { TemplateArgs } from './types';
 
-export interface QueryOptions<TData, TVariables>
+export interface QueryOptions<TData, TVariables extends OperationVariables>
   extends Omit<WatchQueryOptions<TVariables>, 'query'> {
   ssr?: boolean;
   clientId?: string;
@@ -28,10 +28,10 @@ export interface QueryOptions<TData, TVariables>
   onError?: (error: ApolloError) => void;
 }
 
-export type QueryPositionalArgs<TData, TVariables = OperationVariables> = [
-  DocumentNode,
-  QueryOptions<TData, TVariables>?
-];
+export type QueryPositionalArgs<
+  TData,
+  TVariables extends OperationVariables = OperationVariables
+> = [DocumentNode, QueryOptions<TData, TVariables>?];
 
 export class QueryResource<
   TData,

--- a/packages/test-app/tests/unit/custom-query-test.ts
+++ b/packages/test-app/tests/unit/custom-query-test.ts
@@ -27,7 +27,10 @@ import {
   UserInfoQueryVariables
 } from '../../app/mocks/handlers';
 
-function useCustomQuery<TData = unknown, TVariables = OperationVariables>(
+function useCustomQuery<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables
+>(
   parentDestroyable: object,
   args: () => QueryPositionalArgs<TData, TVariables>
 ): QueryResource<TData, TVariables> {
@@ -225,7 +228,7 @@ module('useCustomQuery', function (hooks) {
 
     const expectedError = 'User not found';
     assert.equal(query.error?.message, expectedError);
-    assert.equal(onErrorCalled!.message, expectedError);
+    assert.equal(onErrorCalled.message, expectedError);
   });
 
   test('it returns error with data', async function (assert) {
@@ -269,7 +272,7 @@ module('useCustomQuery', function (hooks) {
 
     const expectedError = 'Data With Error';
     assert.equal(query.error?.message, expectedError);
-    assert.equal(onErrorCalled!.message, expectedError);
+    assert.equal(onErrorCalled.message, expectedError);
   });
 
   test('it does not trigger query update if args references changes but values are the same', async function (assert) {


### PR DESCRIPTION
Same deal as https://github.com/josemarluedke/glimmer-apollo/pull/79
I missed some things due to lack of usage internally. 
This time, I went looking for `TVariables`, and tried to catch-em-all.

Also, with https://github.com/josemarluedke/glimmer-apollo/pull/81, we'll see which TS versions pass / fail in the C.I. summary below.