### PR TITLE
Test against ts@next

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
           - typescript@~4.7.0
           - typescript@~4.8.0
           - typescript@~4.9.0
+          - typescript@next
 
     steps:
       - uses: actions/checkout@v2
@@ -91,9 +92,13 @@ jobs:
           yarn-version: 1.x
       - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn build
-      - run: yarn add --dev ${{ matrix.typescript }}
+      - run: |
+          yarn add --dev ${{ matrix.typescript }}
+          yarn tsc --version
         working-directory: examples/glimmerx
-      - run: yarn add --dev ${{ matrix.typescript }}
+      - run: |
+          yarn add --dev ${{ matrix.typescript }}
+          yarn tsc --version
         working-directory: packages/glimmer-apollo
       - run: yarn test:types
 


### PR DESCRIPTION
I believe it good to test against `next`, because it helps you prepare, and keep up to date.
GitHub doesn't have a good way to make this specific case "allow failure", as far as I know, as that would be ideal, but 🤷 

Also, with https://github.com/josemarluedke/glimmer-apollo/pull/81, we'll see which TS versions pass / fail in the C.I. summary below.