### PR TITLE
Fix waiter left behind when resource is canceled before promise resolves

### DIFF
--- a/packages/test-app/app/components/playground/experiment.hbs
+++ b/packages/test-app/app/components/playground/experiment.hbs
@@ -1,4 +1,4 @@
-<h2>
+<h2 data-test-id="experiment">
   User Info
 </h2>
 

--- a/packages/test-app/app/components/playground/experiment.ts
+++ b/packages/test-app/app/components/playground/experiment.ts
@@ -23,6 +23,7 @@ export default class PlaygroundExperiment extends Component {
   userInfo = useQuery(this, () => [
     USER_INFO,
     {
+      variables: { id: '1-with-delay' },
       errorPolicy: 'all',
       notifyOnNetworkStatusChange: true
     }

--- a/packages/test-app/app/components/playground/index.hbs
+++ b/packages/test-app/app/components/playground/index.hbs
@@ -1,4 +1,4 @@
-<button type="button" {{on "click" this.toggle}}>
+<button type="button" {{on "click" this.toggle}} dates-test-id="toggle">
   Toggle Experiment
 </button>
 

--- a/packages/test-app/app/components/playground/index.ts
+++ b/packages/test-app/app/components/playground/index.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export default class Playground extends Component {
-  @tracked isExperimenting = true;
+  @tracked isExperimenting = false;
 
   toggle = (): void => {
     this.isExperimenting = !this.isExperimenting;

--- a/packages/test-app/app/mocks/handlers.ts
+++ b/packages/test-app/app/mocks/handlers.ts
@@ -84,6 +84,16 @@ export const handlers = [
           }
         })
       );
+    } else if (user && req.variables.id.includes('with-delay')) {
+      return res(
+        ctx.delay(300),
+        ctx.data({
+          user: {
+            __typename: 'User',
+            ...user
+          }
+        })
+      );
     } else if (user) {
       return res(
         ctx.data({

--- a/packages/test-app/tests/integration/components/playground-test.ts
+++ b/packages/test-app/tests/integration/components/playground-test.ts
@@ -1,0 +1,18 @@
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render, waitFor } from '@ember/test-helpers';
+
+module('Integration | Components | Playground', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('no waiters should be left behind when resource is teardown before resolving', async function (this, assert) {
+    await render(hbs`<Playground />`);
+
+    click('[dates-test-id="toggle"]');
+    await waitFor('[data-test-id="experiment"]', { timeout: 100 });
+
+    await click('[dates-test-id="toggle"]');
+    assert.ok(true);
+  });
+});


### PR DESCRIPTION
Paired with @eugenioenko 