### PR TITLE
Proposed fix for #97 – add import to getting-started to work with vite ember apps

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,6 +40,7 @@ of this file can be something like `app/apollo.js`. It's totally up to you.
 
 ```ts:app/apollo.ts
 import { setClient } from 'glimmer-apollo';
+import 'glimmer-apollo/environment-ember';
 import {
   ApolloClient,
   InMemoryCache,


### PR DESCRIPTION
Not sure if it is necessary to add this import as a default import for all users (also non-vite), but I guess it doesn't hurt too much either.?