### PR TITLE
fix: regression: Make variables optional again in `useMutation` options after stricter types in Apollo Client v4

### DIFF
--- a/glimmer-apollo/src/-private/mutation.ts
+++ b/glimmer-apollo/src/-private/mutation.ts
@@ -23,7 +23,8 @@ type Maybe<T> = T | undefined | null;
 export type MutationOptions<
   TData,
   TVariables extends OperationVariables,
-> = Omit<ApolloMutationOptions<TData, TVariables>, 'mutation'> & {
+> = Omit<ApolloMutationOptions<TData, TVariables>, 'mutation' | 'variables'> & {
+  variables?: TVariables;
   clientId?: string;
   onComplete?: (data: Maybe<MaybeMasked<TData>>) => void;
   onError?: (error: ErrorLike) => void;


### PR DESCRIPTION
AC4's stricter types exposed a mismatch where variables are deferred to `.mutate()`.
  
  Apollo Client 4 introduced a conditional VariablesOption type that
  makes `variables` required when TVariables has required fields.
  Since glimmer-apollo's API passes variables at .mutate() call time,
  not at useMutation() definition time, this made the options object
  incorrectly require variables upfront.
  

  
<img width="754" height="160" alt="Screenshot 2026-02-19 at 14 20 13" src="https://github.com/user-attachments/assets/58d8c5c4-a2c2-4ea8-8e12-99d8c635689d" />
